### PR TITLE
Use of lpass status to validate re-login and disabling logout command

### DIFF
--- a/pkg/lastpass/cli.go
+++ b/pkg/lastpass/cli.go
@@ -36,11 +36,15 @@ func VerifyCliExistsOrDie() {
 
 // Login using lastpass-cli
 func Login(username string, password string) error {
-	// echo <PASSWORD> | LPASS_DISABLE_PINENTRY=1 lpass login --trust <USERNAME>
-	out, err := sh.NewSession().SetEnv("LPASS_DISABLE_PINENTRY", "1").Command("echo", password).Command("lpass", "login", "--trust", username).Output()
-	if err != nil || "" == string(out) {
-		// sometimes returns error: "Error: HTTP response code said error" even if the credentials are valid
-		return fmt.Errorf("verify credentials, unable to login: %s", err)
+        _, err := sh.Command("lpass", "status").Output()
+	log.Printf("Checking if already logged in")
+	if err != nil {
+		log.Printf("Doing login")
+		out, err := sh.NewSession().SetEnv("LPASS_DISABLE_PINENTRY", "1").Command("echo", password).Command("lpass", "login", "--trust", username).Output()
+		if err != nil || "" == string(out) {
+			// sometimes returns error: "Error: HTTP response code said error" even if the credentials are valid
+			return fmt.Errorf("verify credentials, unable to login: %s", err)
+		}
 	}
 	log.Printf("Succesfully logged in")
 	return nil
@@ -48,12 +52,8 @@ func Login(username string, password string) error {
 
 // Logout using lastpass-cli
 func Logout() {
-	// lpass logout --force
-	_, err := sh.Command("lpass", "logout", "--force").Output()
-	if err != nil {
-		log.Printf("Ignore error while logging out: %s", err)
-	}
-	log.Printf("Succesfully logged out")
+	// logout is not relevant in operator context.
+        log.Printf("Should logged out, but doing nothing")
 }
 
 // RequestSecrets returns one or more secrets using lastpass-cli

--- a/pkg/lastpass/cli.go
+++ b/pkg/lastpass/cli.go
@@ -53,7 +53,7 @@ func Login(username string, password string) error {
 // Logout using lastpass-cli
 func Logout() {
 	// logout is not relevant in operator context.
-        log.Printf("Should logged out, but doing nothing")
+        log.Printf("Should log out, but doing nothing")
 }
 
 // RequestSecrets returns one or more secrets using lastpass-cli


### PR DESCRIPTION
We hit lastpass rate limit when trying to sync a large amount of secrets.
Because of that, we use `lpass status` before doing a login.
We disabled the logout to keep the operator logged in.